### PR TITLE
Add pixel-art level selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
 
     <!-- Selector de niveles -->
     <div id="level-select" class="screen">
-        <div class="level-select-container">
+        <div class="level-select-container pixel-mode">
             <h2>Selecciona tu Aventura</h2>
             <div class="levels-grid">
                 <div class="level-card unlocked" data-level="1">
@@ -61,6 +61,10 @@
                         <span class="star">☆</span>
                         <span class="star">☆</span>
                     </div>
+                    <div class="level-extra">
+                        <span class="difficulty">⚔️ Dificultad: <span class="diff-value">1</span></span>
+                        <span class="best-score">🏆 Mejor: <span class="score-value">--</span></span>
+                    </div>
                 </div>
                 <div class="level-card locked" data-level="2">
                     <div class="level-number">2</div>
@@ -70,6 +74,10 @@
                         <span class="star">☆</span>
                         <span class="star">☆</span>
                         <span class="star">☆</span>
+                    </div>
+                    <div class="level-extra">
+                        <span class="difficulty">⚔️ Dificultad: <span class="diff-value">2</span></span>
+                        <span class="best-score">🏆 Mejor: <span class="score-value">--</span></span>
                     </div>
                 </div>
                 <div class="level-card locked" data-level="3">
@@ -81,6 +89,10 @@
                         <span class="star">☆</span>
                         <span class="star">☆</span>
                     </div>
+                    <div class="level-extra">
+                        <span class="difficulty">⚔️ Dificultad: <span class="diff-value">3</span></span>
+                        <span class="best-score">🏆 Mejor: <span class="score-value">--</span></span>
+                    </div>
                 </div>
                 <div class="level-card locked" data-level="4">
                     <div class="level-number">4</div>
@@ -90,6 +102,10 @@
                         <span class="star">☆</span>
                         <span class="star">☆</span>
                         <span class="star">☆</span>
+                    </div>
+                    <div class="level-extra">
+                        <span class="difficulty">⚔️ Dificultad: <span class="diff-value">4</span></span>
+                        <span class="best-score">🏆 Mejor: <span class="score-value">--</span></span>
                     </div>
                 </div>
             </div>

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ const LEVELS = {
     target: 0,
     tolerance: 0.2,
     maxSteps: 15,
+    difficulty: 1,
     hints: [
       "El gradiente en x=2 es 2, así que debemos movernos hacia la izquierda",
       "Mientras más lejos del centro, mayor es el gradiente",
@@ -26,6 +27,7 @@ const LEVELS = {
     target: 1,
     tolerance: 0.15,
     maxSteps: 20,
+    difficulty: 2,
     hints: [
       "El mínimo no siempre está en x=0",
       "Observa hacia dónde apunta el gradiente y ve en dirección opuesta",
@@ -41,6 +43,7 @@ const LEVELS = {
     target: 0,
     tolerance: 0.1,
     maxSteps: 25,
+    difficulty: 3,
     hints: [
       "Esta función es más compleja, necesitas ajustar el learning rate",
       "Si oscila mucho, reduce el learning rate",
@@ -56,6 +59,7 @@ const LEVELS = {
     target: -1.42755,
     tolerance: 0.2,
     maxSteps: 40,
+    difficulty: 4,
     hints: [
       "Hay múltiples valles en esta función",
       "El punto de inicio importa mucho",
@@ -479,13 +483,21 @@ function updateLevelSelect() {
   document.querySelectorAll('.level-card').forEach(card => {
     const level = parseInt(card.dataset.level);
     const isUnlocked = gameState.unlockedLevels.has(level);
-    
+    card.querySelector('.diff-value').textContent = LEVELS[level].difficulty;
+    const bestScoreEl = card.querySelector('.score-value');
+    const progress = gameState.levelProgress[level];
+
+    if (progress) {
+      bestScoreEl.textContent = progress.score;
+    } else {
+      bestScoreEl.textContent = '--';
+    }
+
     if (isUnlocked) {
       card.classList.remove('locked');
       card.classList.add('unlocked');
-      
+
       // Mostrar estrellas si completado
-      const progress = gameState.levelProgress[level];
       if (progress) {
         const stars = card.querySelectorAll('.star');
         stars.forEach((star, index) => {

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
 /* === VARIABLES GLOBALES === */
 :root {
   --primary-color: #6366f1;
@@ -15,6 +17,12 @@
   --gradient-secondary: linear-gradient(135deg, var(--secondary-color), #f97316);
   --shadow-soft: 0 4px 20px rgba(0, 0, 0, 0.3);
   --shadow-strong: 0 8px 32px rgba(0, 0, 0, 0.5);
+  /* Estilo Pixel Art */
+  --pixel-font: 'Press Start 2P', cursive;
+  --pixel-bg: #0d0c1d;
+  --pixel-border: #3f3f3f;
+  --pixel-text: #f5f5f5;
+  --pixel-accent: #fbbf24;
 }
 
 /* === RESET Y BASE === */
@@ -227,16 +235,19 @@ body {
   max-width: 1200px;
   padding: 2rem;
   text-align: center;
+  font-family: var(--pixel-font);
+}
+
+.pixel-mode {
+  background: var(--pixel-bg);
+  color: var(--pixel-text);
 }
 
 .level-select-container h2 {
   font-size: 2.5rem;
   font-weight: 700;
   margin-bottom: 3rem;
-  background: var(--gradient-secondary);
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--pixel-accent);
 }
 
 .levels-grid {
@@ -247,21 +258,26 @@ body {
 }
 
 .level-card {
-  background: var(--dark-surface);
-  border: 2px solid var(--border-color);
-  border-radius: 20px;
-  padding: 2rem;
+  background: var(--pixel-bg);
+  border: 4px solid var(--pixel-border);
+  border-radius: 8px;
+  padding: 1.5rem;
   text-align: center;
   cursor: pointer;
   transition: all 0.3s ease;
   position: relative;
   overflow: hidden;
+  font-family: var(--pixel-font);
+  color: var(--pixel-text);
+  text-shadow: 0 0 4px #000;
 }
 
 .level-card.unlocked:hover {
-  transform: translateY(-8px);
-  border-color: var(--primary-color);
-  box-shadow: var(--shadow-strong);
+  transform: translateY(-4px);
+  border-color: var(--pixel-accent);
+  box-shadow: 0 0 10px var(--pixel-accent);
+  background: var(--pixel-accent);
+  color: var(--pixel-bg);
 }
 
 .level-card.locked {
@@ -270,39 +286,51 @@ body {
 }
 
 .level-number {
-  width: 60px;
-  height: 60px;
-  background: var(--gradient-primary);
-  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  background: var(--pixel-accent);
+  border: 4px solid var(--pixel-border);
+  border-radius: 4px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.5rem;
+  font-size: 1rem;
   font-weight: 800;
-  color: white;
+  color: var(--pixel-bg);
   margin: 0 auto 1rem;
 }
 
 .level-card h3 {
-  font-size: 1.5rem;
+  font-size: 1rem;
   margin-bottom: 0.5rem;
-  color: var(--text-primary);
+  color: var(--pixel-text);
 }
 
 .level-card p {
-  color: var(--text-secondary);
-  margin-bottom: 1.5rem;
+  color: var(--pixel-text);
+  margin-bottom: 1rem;
+  font-size: 0.8rem;
 }
 
 .level-stars {
   display: flex;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
+  font-size: 1rem;
 }
 
 .star {
-  font-size: 1.5rem;
-  color: var(--secondary-color);
+  font-size: 1rem;
+  color: var(--pixel-accent);
+}
+
+.level-extra {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.6rem;
+  color: var(--pixel-text);
 }
 
 .back-btn {


### PR DESCRIPTION
## Summary
- import Press Start 2P font and create pixel-art variables
- restyle level select cards with a retro look
- show difficulty and best score for each level
- update logic to fill new info in the level selector

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885a34c65ac8330abaaff6d9ebfa9b6