### PR TITLE
Add Support Vector Machine topic

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,10 @@
                         <span class="btn-icon">📊</span>
                         Progreso
                     </button>
+                    <button class="menu-btn" id="topics-btn">
+                        <span class="btn-icon">🗂️</span>
+                        Temas
+                    </button>
                 </nav>
             </div>
         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -428,6 +428,10 @@ function initializeEvents() {
     gameState.currentLevel = 1;
     startGame();
   });
+
+  document.getElementById('topics-btn').addEventListener('click', () => {
+    window.location.href = '/src/temas/index.html';
+  });
   
   // Selector de niveles
   document.getElementById('back-to-menu').addEventListener('click', () => {

--- a/src/temas/index.html
+++ b/src/temas/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/vite.svg">
+  <title>Temas de IA Interactiva</title>
+  <link rel="stylesheet" href="/src/style.css">
+</head>
+<body class="pixel-mode">
+  <div class="level-select-container">
+    <h2>Temas de Aprendizaje</h2>
+    <div class="levels-grid">
+      <a class="level-card unlocked" href="/src/temas/descenso-de-gradiente/index.html">
+        <div class="level-number">1</div>
+        <h3>Descenso de Gradiente</h3>
+        <p>Optimización básica</p>
+      </a>
+      <a class="level-card unlocked" href="/src/temas/regresion-logistica/index.html">
+        <div class="level-number">2</div>
+        <h3>Regresión Logística</h3>
+        <p>Clasificación binaria</p>
+      </a>
+      <a class="level-card unlocked" href="/src/temas/support-vector-machine/index.html">
+        <div class="level-number">3</div>
+        <h3>SVM</h3>
+        <p>Maximizando el margen</p>
+      </a>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/temas/support-vector-machine/index.html
+++ b/src/temas/support-vector-machine/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Máquina de Soporte Vectorial</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container pixel-mode">
+    <header>
+      <h1>Máquina de Soporte Vectorial</h1>
+    </header>
+    <section class="learning">
+      <h2>Sección de Aprendizaje</h2>
+      <p>Basado en el libro <em>Hands-On Machine Learning with Scikit-Learn, Keras &amp; TensorFlow</em> de Aurélien Géron.</p>
+      <p>Una SVM busca la frontera que maximiza el margen entre dos clases.</p>
+    </section>
+    <section class="demo">
+      <canvas id="chart"></canvas>
+      <div class="controls">
+        <label for="lr">Tasa de aprendizaje: <span id="lr-value">0.1</span></label>
+        <input type="range" id="lr" min="0.01" max="1" step="0.01" value="0.1">
+        <button id="train-btn">Entrenar</button>
+      </div>
+      <div class="pixel-art">
+        <img src="svm-sprite.svg" alt="Pixel Art SVM">
+      </div>
+    </section>
+  </div>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/src/temas/support-vector-machine/main.js
+++ b/src/temas/support-vector-machine/main.js
@@ -1,0 +1,98 @@
+import Chart from 'https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.esm.js';
+
+// === DATOS DE ENTRENAMIENTO ===
+const datos = [
+  { x: -2, y: -1 },
+  { x: -1.5, y: -1 },
+  { x: -1, y: -1 },
+  { x: 1, y: 1 },
+  { x: 1.5, y: 1 },
+  { x: 2, y: 1 }
+];
+
+let peso = 0;
+let sesgo = 0;
+let tasaAprendizaje = 0.1;
+let animacionId;
+
+const ctx = document.getElementById('chart');
+const chart = new Chart(ctx, {
+  type: 'scatter',
+  data: {
+    datasets: [
+      {
+        label: 'Clase +1',
+        data: datos.filter(d => d.y === 1),
+        backgroundColor: '#00d4ff'
+      },
+      {
+        label: 'Clase -1',
+        data: datos.filter(d => d.y === -1),
+        backgroundColor: '#ff6b6b'
+      },
+      {
+        label: 'Modelo',
+        data: [],
+        type: 'line',
+        borderColor: '#ffffff',
+        borderWidth: 2,
+        fill: false
+      }
+    ]
+  },
+  options: {
+    animation: false,
+    scales: {
+      x: { min: -3, max: 3 },
+      y: { min: -2, max: 2 }
+    }
+  }
+});
+
+const actualizaModelo = () => {
+  const puntos = [];
+  for (let x = -3; x <= 3; x += 0.1) {
+    puntos.push({ x, y: peso * x + sesgo });
+  }
+  chart.data.datasets[2].data = puntos;
+  chart.update();
+};
+
+const calculaGradiente = () => {
+  let dw = 0;
+  let db = 0;
+  for (const { x, y } of datos) {
+    const margen = y * (peso * x + sesgo);
+    if (margen < 1) {
+      dw += -y * x;
+      db += -y;
+    }
+  }
+  dw /= datos.length;
+  db /= datos.length;
+  return { dw, db };
+};
+
+const pasoEntrenamiento = () => {
+  const { dw, db } = calculaGradiente();
+  peso -= tasaAprendizaje * dw;
+  sesgo -= tasaAprendizaje * db;
+  actualizaModelo();
+};
+
+const entrena = () => {
+  cancelAnimationFrame(animacionId);
+  const ciclo = () => {
+    pasoEntrenamiento();
+    animacionId = requestAnimationFrame(ciclo);
+  };
+  ciclo();
+};
+
+document.getElementById('train-btn').addEventListener('click', entrena);
+document.getElementById('lr').addEventListener('input', e => {
+  tasaAprendizaje = parseFloat(e.target.value);
+  document.getElementById('lr-value').textContent = tasaAprendizaje.toFixed(2);
+});
+
+actualizaModelo();

--- a/src/temas/support-vector-machine/style.css
+++ b/src/temas/support-vector-machine/style.css
@@ -1,0 +1,35 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+:root {
+  --pixel-bg: #1a1a2e;
+  --pixel-accent: #00d4ff;
+  --pixel-text: #ffffff;
+  --pixel-dark: #000000;
+}
+
+body {
+  margin: 0;
+  background: var(--pixel-bg);
+  color: var(--pixel-text);
+  font-family: 'Press Start 2P', monospace;
+}
+
+.container {
+  padding: 1rem;
+  text-align: center;
+}
+
+canvas {
+  background: #0f0f23;
+  border: 2px solid var(--pixel-accent);
+  margin-bottom: 1rem;
+}
+
+.controls {
+  margin-bottom: 1rem;
+}
+
+.pixel-art img {
+  width: 64px;
+  image-rendering: pixelated;
+}

--- a/src/temas/support-vector-machine/svm-sprite.svg
+++ b/src/temas/support-vector-machine/svm-sprite.svg
@@ -1,0 +1,6 @@
+<svg width="64" height="64" xmlns="http://www.w3.org/2000/svg">
+  <!-- Pixel Art SVM -->
+  <rect width="64" height="64" fill="#00ff00" />
+  <line x1="2" y1="2" x2="62" y2="62" stroke="#ffffff" stroke-width="2" />
+  <line x1="2" y1="62" x2="62" y2="2" stroke="#ffffff" stroke-width="2" />
+</svg>


### PR DESCRIPTION
## Summary
- create basic Support Vector Machine topic module
- include demo with simple SGD-based SVM visualization
- add topics menu with links to each module

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885b2e69d888330aaf146643089902b